### PR TITLE
Add DDF params_for_create

### DIFF
--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager.rb
@@ -29,8 +29,84 @@ class ManageIQ::Providers::OracleCloud::CloudManager < ManageIQ::Providers::Clou
     @description ||= "Oracle Cloud".freeze
   end
 
-  def description
-    ManageIQ::Providers::OracleCloud::Regions.find_by_name(provider_region)[:description]
+  def self.params_for_create
+    {
+      :fields => [
+        {
+          :component    => "select",
+          :id           => "provider_region",
+          :name         => "provider_region",
+          :label        => _("Region"),
+          :isRequired   => true,
+          :validate     => [{:type => "required"}],
+          :includeEmpty => true,
+          :options      => provider_region_options
+        },
+        {
+          :component  => "text-field",
+          :id         => "uid_ems",
+          :name       => "uid_ems",
+          :label      => _("Tenant ID"),
+          :isRequired => true,
+          :validate   => [{:type => "required"}]
+        },
+        {
+          :component => 'sub-form',
+          :name      => 'endpoints-subform',
+          :id        => 'endpoints-subform',
+          :title     => _("Endpoints"),
+          :fields    => [
+            {
+              :component              => 'validate-provider-credentials',
+              :id                     => 'authentications.default.valid',
+              :name                   => 'authentications.default.valid',
+              :skipSubmit             => true,
+              :isRequired             => true,
+              :validationDependencies => %w[type zone_id provider_region uid_ems],
+              :fields                 => [
+                {
+                  :component  => "text-field",
+                  :id         => "authentications.default.userid",
+                  :name       => "authentications.default.userid",
+                  :label      => _("User ID"),
+                  :helperText => _("Should have privileged access, such as root or administrator."),
+                  :isRequired => true,
+                  :validate   => [{:type => "required"}]
+                },
+                {
+                  :component      => "password-field",
+                  :componentClass => 'textarea',
+                  :rows           => 10,
+                  :id             => "authentications.default.auth_key",
+                  :name           => "authentications.default.auth_key",
+                  :label          => _("Private Key"),
+                  :type           => "password",
+                  :isRequired     => true,
+                  :validate       => [{:type => "required"}]
+                },
+                {
+                  :component      => "text-field",
+                  :componentClass => 'textarea',
+                  :rows           => 10,
+                  :id             => "authentications.default.public_key",
+                  :name           => "authentications.default.public_key",
+                  :label          => "Public Key",
+                  :isRequired     => true,
+                  :validate       => [{:type => "required"}]
+                }
+              ],
+            },
+          ]
+        }
+      ]
+    }
+  end
+
+  private_class_method def self.provider_region_options
+    ManageIQ::Providers::OracleCloud::Regions
+      .all
+      .sort_by { |r| r[:name].downcase }
+      .map { |r| {:label => r[:name], :value => r[:name]} }
   end
 
   validates :provider_region, :inclusion => {:in => ManageIQ::Providers::OracleCloud::Regions.names}


### PR DESCRIPTION
Adding an Oracle Cloud provider requires a user id, tenancy id, region, and public key/private key pair.