### PR TITLE
Add event catcher for Oracle Cloud

### DIFF
--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager.rb
@@ -3,6 +3,7 @@ class ManageIQ::Providers::OracleCloud::CloudManager < ManageIQ::Providers::Clou
   require_nested :AvailabilityZone
   require_nested :CloudVolume
   require_nested :EventCatcher
+  require_nested :EventParser
   require_nested :Flavor
   require_nested :Refresher
   require_nested :RefreshWorker

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::OracleCloud::CloudManager < ManageIQ::Providers::Clou
   require_nested :AuthKeyPair
   require_nested :AvailabilityZone
   require_nested :CloudVolume
+  require_nested :EventCatcher
   require_nested :Flavor
   require_nested :Refresher
   require_nested :RefreshWorker

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher.rb
@@ -1,3 +1,4 @@
 class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
   require_nested :Runner
+  require_nested :Stream
 end

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/runner.rb
@@ -10,6 +10,7 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner < Man
     ensure_event_stream
 
     event_stream.poll do |event|
+      process_event(event)
     end
   ensure
     stop_event_monitor
@@ -22,8 +23,8 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner < Man
 
   private
 
-  attr_reader :ems
-  attr_writer :event_stream
+  attr_reader   :ems
+  attr_accessor :event_stream
 
   def parse_event(event)
     ManageIQ::Providers::OracleCloud::CloudManager::EventParser.event_to_hash(event, @cfg[:ems_id])

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/runner.rb
@@ -9,7 +9,10 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner < Man
     event_monitor_running
     ensure_event_stream
 
-    event_stream.poll { |event| process_event(event) }
+    event_stream.poll do |events|
+      @queue.enq(events)
+      sleep_poll_normal
+    end
   ensure
     stop_event_monitor
   end

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/runner.rb
@@ -9,9 +9,7 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner < Man
     event_monitor_running
     ensure_event_stream
 
-    event_stream.poll do |event|
-      process_event(event)
-    end
+    event_stream.poll { |event| process_event(event) }
   ensure
     stop_event_monitor
   end
@@ -31,9 +29,7 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner < Man
   end
 
   def ensure_event_stream
-    self.event_stream ||= begin
-      ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Stream.new(ems)
-    end
+    self.event_stream ||= ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Stream.new(ems)
   end
 
   def reset_event_stream

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/runner.rb
@@ -1,0 +1,41 @@
+class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
+  def stop_event_monitor
+    event_stream&.stop
+  ensure
+    reset_event_stream
+  end
+
+  def monitor_events
+    event_monitor_running
+    ensure_event_stream
+
+    event_stream.poll do |event|
+    end
+  ensure
+    stop_event_monitor
+  end
+
+  def process_event(event)
+    _log.info("#{log_prefix} Caught event [#{event}]")
+    EmsEvent.add_queue("add", @cfg[:ems_id], parse_event(event))
+  end
+
+  private
+
+  attr_reader :ems
+  attr_writer :event_stream
+
+  def parse_event(event)
+    ManageIQ::Providers::OracleCloud::CloudManager::EventParser.event_to_hash(event, @cfg[:ems_id])
+  end
+
+  def ensure_event_stream
+    self.event_stream ||= begin
+      ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Stream.new(ems)
+    end
+  end
+
+  def reset_event_stream
+    self.event_stream = nil
+  end
+end

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/runner.rb
@@ -19,7 +19,7 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner < Man
 
   def process_event(event)
     _log.info("#{log_prefix} Caught event [#{event}]")
-    EmsEvent.add_queue("add", @cfg[:ems_id], parse_event(event))
+    EmsEvent.add_queue("add", ems_id, parse_event(event))
   end
 
   private
@@ -28,7 +28,7 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner < Man
   attr_accessor :event_stream
 
   def parse_event(event)
-    ManageIQ::Providers::OracleCloud::CloudManager::EventParser.event_to_hash(event, @cfg[:ems_id])
+    ManageIQ::Providers::OracleCloud::CloudManager::EventParser.event_to_hash(event, ems_id)
   end
 
   def ensure_event_stream
@@ -37,5 +37,9 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner < Man
 
   def reset_event_stream
     self.event_stream = nil
+  end
+
+  def ems_id
+    @cfg[:ems_id]
   end
 end

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/stream.rb
@@ -29,9 +29,10 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Stream
 
       cursor = result.headers["opc-next-cursor"]
 
-      Array(result.data).each { |message| yield decode_message(message) }
+      messages = Array(result.data)
+      events   = messages.collect { |message| decode_message(message) }
 
-      sleep(poll_sleep)
+      yield events
     end
   end
 

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/stream.rb
@@ -1,0 +1,16 @@
+class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Stream
+  attr_reader :ems
+
+  def initialize(ems)
+    @ems = ems
+  end
+
+  def stop
+  end
+
+  def poll
+    loop do
+      sleep(1)
+    end
+  end
+end

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/stream.rb
@@ -27,8 +27,11 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Stream
       result = stream_client(stream).get_messages(stream.id, cursor)
       next if result.status != 200
 
+      # Grab the next cursor from the results
       cursor = result.headers["opc-next-cursor"]
 
+      # Each message is Base64 encoded so we have decode and JSON parse it
+      # before yielding to the block
       messages = Array(result.data)
       events   = messages.collect { |message| decode_message(message) }
 

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/stream.rb
@@ -9,8 +9,43 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Stream
   end
 
   def poll
+    stream = find_or_create_manageiq_events_stream
+
     loop do
       sleep(1)
     end
+  end
+
+  private
+
+  def find_or_create_manageiq_events_stream
+    streams = stream_admin_client.list_streams(:compartment_id => compartment_id).data
+
+    manageiq_events_stream = streams.detect { |stream| stream.name == "manageiq-events" }
+    manageiq_events_stream || create_manageiq_events_stream
+  end
+
+  def create_manageiq_events_stream
+    create_stream_details = OCI::Streaming::Models::CreateStreamDetails.new(
+      :name           => "manageiq-events",
+      :compartment_id => ems.uid_ems,
+      :partitions     => 1,
+      :stream_pool_id => default_stream_pool&.id
+    )
+
+    stream_admin_client.create_stream(create_stream_details).data
+  end
+
+  def default_stream_pool
+    stream_pools = stream_admin_client.list_stream_pools(:compartment_id => compartment_id).data
+    stream_pools.detect { |stream_pool| stream_pool.name == "DefaultPool" }
+  end
+
+  def stream_admin_client
+    @stream_admin_client ||= ems.connect(:service => "Streaming::StreamAdminClient")
+  end
+
+  def compartment_id
+    ems.uid_ems
   end
 end

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_parser.rb
@@ -1,0 +1,7 @@
+class ManageIQ::Providers::OracleCloud::CloudManager::EventParser
+  def self.event_to_hash(event, ems_id = nil)
+    {
+      :source => "OracleCloud"
+    }
+  end
+end

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_parser.rb
@@ -22,7 +22,7 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventParser
     return if event_source.nil?
 
     event_parser_method = "parse_#{event_source}_event!"
-    send(event_parser_method, event, event_hash)
+    send(event_parser_method, event, event_hash) if respond_to?(event_parser_method)
 
     event_hash
   end

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_parser.rb
@@ -1,7 +1,28 @@
 class ManageIQ::Providers::OracleCloud::CloudManager::EventParser
+  def self.parse_compute_api_event!(event, event_hash)
+    event_type = event["eventType"]
+    if event_type.start_with?("com.oraclecloud.computeapi.instance")
+      event_hash["vm_ems_ref"] = event.dig("data", "resourceId")
+      event_hash["vm_name"]    = event.dig("data", "resourceName")
+    end
+  end
+
   def self.event_to_hash(event, ems_id = nil)
-    {
-      :source => "OracleCloud"
+    event_hash = {
+      :event_type => event["eventType"],
+      :source     => "ORACLE",
+      :ems_ref    => event["eventID"],
+      :ems_id     => ems_id,
+      :timestamp  => event["eventTime"],
+      :full_data  => event
     }
+
+    event_source = event["source"]&.underscore
+    return if event_source.nil?
+
+    event_parser_method = "parse_#{event_source}_event!"
+    send(event_parser_method, event, event_hash)
+
+    event_hash
   end
 end

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_parser.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventParser
   def self.parse_compute_api_event!(event, event_hash)
     event_type = event["eventType"]
     if event_type.start_with?("com.oraclecloud.computeapi.instance")
+      event_hash["vm_uid_ems"] = event.dig("data", "resourceId")
       event_hash["vm_ems_ref"] = event.dig("data", "resourceId")
       event_hash["vm_name"]    = event.dig("data", "resourceName")
     end

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_parser.rb
@@ -2,9 +2,9 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventParser
   def self.parse_compute_api_event!(event, event_hash)
     event_type = event["eventType"]
     if event_type.start_with?("com.oraclecloud.computeapi.instance")
-      event_hash["vm_uid_ems"] = event.dig("data", "resourceId")
-      event_hash["vm_ems_ref"] = event.dig("data", "resourceId")
-      event_hash["vm_name"]    = event.dig("data", "resourceName")
+      event_hash[:vm_uid_ems] = event.dig("data", "resourceId")
+      event_hash[:vm_ems_ref] = event.dig("data", "resourceId")
+      event_hash[:vm_name]    = event.dig("data", "resourceName")
     end
   end
 

--- a/app/models/manageiq/providers/oracle_cloud/manager_mixin.rb
+++ b/app/models/manageiq/providers/oracle_cloud/manager_mixin.rb
@@ -6,7 +6,9 @@ module ManageIQ::Providers::OracleCloud::ManagerMixin
   end
 
   def connect(options = {})
-    authentication = authentication_best_fit(options[:auth_type])
+    auth_type = options.delete(:auth_type)
+
+    authentication = authentication_best_fit(auth_type)
     config = self.class.raw_connect(
       uid_ems,
       authentication.userid,
@@ -15,11 +17,12 @@ module ManageIQ::Providers::OracleCloud::ManagerMixin
       provider_region
     )
 
-    if options[:service]
-      api_client_klass = "OCI::#{options[:service]}".safe_constantize
+    service = options.delete(:service)
+    if service
+      api_client_klass = "OCI::#{service}".safe_constantize
       raise ArgumentError, _("Invalid service") if api_client_klass.nil?
 
-      api_client_klass.new(:config => config)
+      api_client_klass.new(options.reverse_merge(:config => config))
     else
       config
     end

--- a/spec/models/manageiq/providers/oracle_cloud/cloud_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/oracle_cloud/cloud_manager/event_parser_spec.rb
@@ -1,0 +1,61 @@
+describe ManageIQ::Providers::OracleCloud::CloudManager::EventParser do
+  describe ".event_to_hash" do
+    let(:ems) { FactoryBot.create(:ems_oracle_cloud) }
+
+    context "vm event" do
+      let(:raw_event) do
+        {
+          "eventType"          => "com.oraclecloud.computeapi.instanceaction.begin",
+          "cloudEventsVersion" => "0.1",
+          "eventTypeVersion"   => "2.0",
+          "source"             => "computeApi",
+          "eventTime"          => "2021-03-16T17:15:16Z",
+          "contentType"        => "application/json",
+          "data"               => {
+            "compartmentId"      => "ocid1.tenancy.oc1..abcdefg",
+            "compartmentName"    => "manageiq",
+            "resourceName"       => "instance-20210223-1239",
+            "resourceId"         => "ocid1.instance.oc1.iad.abcdefg",
+            "availabilityDomain" => "AD3",
+            "freeformTags"       => {},
+            "definedTags"        => {
+              "Oracle-Tags" => {
+                "CreatedBy" => "oracleidentitycloudservice/accounts@manageiq.org",
+                "CreatedOn" => "2021-02-23T18:38:00.683Z"
+              }
+            },
+            "additionalDetails"  => {
+              "volumeId"           => "null",
+              "instanceActionType" => "softstop",
+              "imageId"            => "ocid1.image.oc1.iad.aaaaaaaa",
+              "X-Real-Port"        => 55_060,
+              "shape"              => "VM.Standard.E2.1.Micro",
+              "type"               => "CustomerVmi"
+            }
+          },
+          "eventID"            => "25993e24-c9a4-44c2-9687-baf110f413b6",
+          "extensions"         => {"compartmentId"=>"ocid1.tenancy.oc1..abcdefg"}
+        }
+      end
+
+      it "parses the common event attributes" do
+        parsed_hash = described_class.event_to_hash(raw_event, ems.id)
+        expect(parsed_hash).to include(
+          :event_type => "com.oraclecloud.computeapi.instanceaction.begin",
+          :source     => "ORACLE",
+          :ems_ref    => "25993e24-c9a4-44c2-9687-baf110f413b6",
+          :ems_id     => ems.id,
+          :timestamp  => "2021-03-16T17:15:16Z"
+        )
+      end
+
+      it "includes the vm ems_ref and name in the event hash" do
+        parsed_hash = described_class.event_to_hash(raw_event, ems.id)
+        expect(parsed_hash).to include(
+          :vm_ems_ref => "ocid1.instance.oc1.iad.abcdefg",
+          :vm_name    => "instance-20210223-1239"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This uses the Oracle Cloud Events service (https://docs.oracle.com/en-us/iaas/Content/Events/Concepts/eventsoverview.htm) and the Streaming service (https://docs.oracle.com/en-us/iaas/Content/Streaming/Concepts/streamingoverview.htm) which is basically kafka behind the OCI API.

The Events service has Rules which match events with filters and actions one of which is publish to a streaming service topic.

TODO:
- [x] Automatically create Streaming service streams (aka topic)
- [x] Automatically create Events service rule (first pass document user how to create this?)
- [x] Switch simple Cursor to GroupCursor
- [x] Spec tests