### PR TITLE
Fix public-key text area component

### DIFF
--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager.rb
@@ -89,14 +89,13 @@ class ManageIQ::Providers::OracleCloud::CloudManager < ManageIQ::Providers::Clou
                   :validate       => [{:type => "required"}]
                 },
                 {
-                  :component      => "text-field",
-                  :componentClass => 'textarea',
-                  :rows           => 10,
-                  :id             => "authentications.default.public_key",
-                  :name           => "authentications.default.public_key",
-                  :label          => "Public Key",
-                  :isRequired     => true,
-                  :validate       => [{:type => "required"}]
+                  :component  => "textarea",
+                  :rows       => 10,
+                  :id         => "authentications.default.public_key",
+                  :name       => "authentications.default.public_key",
+                  :label      => "Public Key",
+                  :isRequired => true,
+                  :validate   => [{:type => "required"}]
                 }
               ],
             },

--- a/app/models/manageiq/providers/oracle_cloud/manager_mixin.rb
+++ b/app/models/manageiq/providers/oracle_cloud/manager_mixin.rb
@@ -45,6 +45,8 @@ module ManageIQ::Providers::OracleCloud::ManagerMixin
       default_endpoint = args.dig("authentications", "default")
       user, private_key, public_key = default_endpoint&.values_at("userid", "auth_key", "public_key")
 
+      private_key ||= find(args["id"]).authentication_token("default")
+
       config = raw_connect(tenant, user, private_key, public_key, region)
       identity_api = OCI::Identity::IdentityClient.new(:config => config)
       !!identity_api.get_user(user)


### PR DESCRIPTION
This fixes the public-key text area after the recent switch to carbon to maintain newlines.  The private key component is still broken however.

https://github.com/ManageIQ/manageiq-ui-classic/issues/7647#issuecomment-793923062