### PR TITLE
Add blacklisted event filtering support

### DIFF
--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/runner.rb
@@ -18,8 +18,12 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner < Man
   end
 
   def process_event(event)
-    _log.info("#{log_prefix} Caught event [#{event}]")
-    EmsEvent.add_queue("add", ems_id, parse_event(event))
+    if filtered?(event)
+      _log.debug("#{log_prefix} Skipping filtered event #{event["eventType"]}")
+    else
+      _log.info("#{log_prefix} Caught event [#{event["eventType"]}] [#{event}]")
+      EmsEvent.add_queue("add", ems_id, parse_event(event))
+    end
   end
 
   private
@@ -29,6 +33,10 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner < Man
 
   def parse_event(event)
     ManageIQ::Providers::OracleCloud::CloudManager::EventParser.event_to_hash(event, ems_id)
+  end
+
+  def filtered?(event)
+    filtered_events.include?(event["eventType"])
   end
 
   def ensure_event_stream

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,10 @@
+---
 :ems:
   :ems_oracle_cloud:
-    :blacklisted_event_names: []
+    :blacklisted_event_names:
+    - com.oraclecloud.resourcequeryservice.searchresources
+    - com.oraclecloud.identitysignon.federatedinteractiveloginattempt
+    - serviceapi
     :event_handling:
       :event_groups:
 :ems_refresh:


### PR DESCRIPTION
There are a few events that Oracle Cloud raises that aren't very helpful, add event filtering support and some initial blacklisted event types