### PR TITLE
Simplify targeted-refresh subclasses

### DIFF
--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/vm.rb
@@ -46,7 +46,7 @@ class ManageIQ::Providers::OracleCloud::CloudManager::Vm < ManageIQ::Providers::
     case raw_power_state.downcase
     when /running/, /starting/
       "on"
-    when /shutdown/, /stopping/, /terminating/, /terminated/
+    when /shutdown/, /stopping/, /stopped/, /terminating/, /terminated/
       "off"
     else
       "unknown"

--- a/app/models/manageiq/providers/oracle_cloud/inventory.rb
+++ b/app/models/manageiq/providers/oracle_cloud/inventory.rb
@@ -2,17 +2,4 @@ class ManageIQ::Providers::OracleCloud::Inventory < ManageIQ::Providers::Invento
   require_nested :Collector
   require_nested :Parser
   require_nested :Persister
-
-  def self.default_manager_name
-    "CloudManager"
-  end
-
-  def self.parser_classes_for(ems, target)
-    case target
-    when InventoryRefresh::TargetCollection
-      [ManageIQ::Providers::OracleCloud::Inventory::Parser]
-    else
-      super
-    end
-  end
 end

--- a/app/models/manageiq/providers/oracle_cloud/inventory/parser.rb
+++ b/app/models/manageiq/providers/oracle_cloud/inventory/parser.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::OracleCloud::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
   require_nested :CloudManager
   require_nested :NetworkManager
+  require_nested :TargetCollection
 
   def parse
     availability_domains

--- a/app/models/manageiq/providers/oracle_cloud/inventory/parser/target_collection.rb
+++ b/app/models/manageiq/providers/oracle_cloud/inventory/parser/target_collection.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::OracleCloud::Inventory::Parser::TargetCollection < ManageIQ::Providers::OracleCloud::Inventory::Parser
+end

--- a/app/models/manageiq/providers/oracle_cloud/inventory/persister/target_collection.rb
+++ b/app/models/manageiq/providers/oracle_cloud/inventory/persister/target_collection.rb
@@ -2,8 +2,4 @@ class ManageIQ::Providers::OracleCloud::Inventory::Persister::TargetCollection <
   def targeted?
     true
   end
-
-  def strategy
-    :local_db_find_missing_references
-  end
 end

--- a/spec/models/manageiq/providers/oracle_cloud/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/oracle_cloud/cloud_manager/refresher_spec.rb
@@ -20,149 +20,6 @@ describe ManageIQ::Providers::OracleCloud::CloudManager::Refresher do
           assert_specific_cloud_volume
         end
       end
-
-      def assert_specific_availability_zone
-        az = ems.availability_zones.find_by(:name => "Foha:US-ASHBURN-AD-3")
-        expect(az).to have_attributes(
-          :name    => "Foha:US-ASHBURN-AD-3",
-          :ems_ref => "ocid1.availabilitydomain.oc1..aaaaaaaatrwxaogr7dl4yschqtrmqrdv6uzis3mgbnomiagqrfhcb7mxsfdq",
-          :type    => "ManageIQ::Providers::OracleCloud::CloudManager::AvailabilityZone"
-        )
-      end
-
-      def assert_specific_cloud_tenant
-        cloud_tenant = ems.cloud_tenants.find_by(:ems_ref => root_tenant_id)
-        expect(cloud_tenant).to have_attributes(
-          :ems_ref     => root_tenant_id,
-          :name        => "manageiq",
-          :description => "manageiq",
-          :enabled     => true,
-          :parent      => nil
-        )
-      end
-
-      def assert_specific_flavor
-        flavor = ems.flavors.find_by(:ems_ref => "VM.Standard.E2.1.Micro")
-        expect(flavor).to have_attributes(
-          :name    => "VM.Standard.E2.1.Micro",
-          :cpus    => 1,
-          :memory  => 1.gigabyte,
-          :ems_ref => "VM.Standard.E2.1.Micro",
-          :type    => "ManageIQ::Providers::OracleCloud::CloudManager::Flavor"
-        )
-      end
-
-      def assert_specific_instance
-        vm = ems.vms.find_by(:ems_ref => "ocid1.instance.oc1.iad.anuwcljtw3enqvycv47dx6ewcsmpjqzazpqxblsikzzkiw7ubhhgopqf3i3q")
-        expect(vm).to have_attributes(
-          :vendor            => "oracle",
-          :name              => "instance-20210223-1239",
-          :location          => root_tenant_id,
-          :uid_ems           => "ocid1.instance.oc1.iad.anuwcljtw3enqvycv47dx6ewcsmpjqzazpqxblsikzzkiw7ubhhgopqf3i3q",
-          :power_state       => "on",
-          :type              => "ManageIQ::Providers::OracleCloud::CloudManager::Vm",
-          :ems_ref           => "ocid1.instance.oc1.iad.anuwcljtw3enqvycv47dx6ewcsmpjqzazpqxblsikzzkiw7ubhhgopqf3i3q",
-          :flavor            => ems.flavors.find_by(:ems_ref => "VM.Standard.E2.1.Micro"),
-          :raw_power_state   => "RUNNING",
-          :genealogy_parent  => ems.miq_templates.find_by(:ems_ref => "ocid1.image.oc1.iad.aaaaaaaaqdc7jslbtue7abhwvxaq3ihvazfvihhs2rwk2mvciv36v7ux5sda"),
-          :cloud_tenant      => ems.cloud_tenants.find_by(:ems_ref => root_tenant_id),
-          :availability_zone => ems.availability_zones.find_by(:name => "Foha:US-ASHBURN-AD-3")
-        )
-
-        expect(vm.network_ports.count).to eq(1)
-        expect(vm.network_ports.first).to have_attributes(
-          :ems_ref      => "ocid1.vnic.oc1.iad.abuwcljt5ddcgxptz6arjcdfpje74zydmpfrpqeg2kjkbwiax26rwo36nzfa",
-          :name         => "instance-20210223-1239",
-          :type         => "ManageIQ::Providers::OracleCloud::NetworkManager::NetworkPort",
-          :mac_address  => "02:00:17:09:70:43",
-          :status       => "AVAILABLE",
-          :device       => vm,
-          :cloud_tenant => ems.cloud_tenants.find_by(:ems_ref => root_tenant_id)
-        )
-
-        expect(vm.cloud_subnets.count).to eq(1)
-        expect(vm.cloud_subnets.first).to have_attributes(
-          :ems_ref       => "ocid1.subnet.oc1.iad.aaaaaaaanmzazihpr74jpktyicjibszf3dyye4tho43nxemsixabsc7ugdqq",
-          :name          => "subnet-20210223-1239",
-          :cloud_network => ems.cloud_networks.find_by(:ems_ref => "ocid1.vcn.oc1.iad.amaaaaaaw3enqvya24pw6a2kqhuwllzk5447qch6cdemiqvxdlnahagepodq"),
-          :cidr          => "10.0.0.0/24",
-          :status        => "AVAILABLE",
-          :gateway       => "10.0.0.1",
-          :cloud_tenant  => ems.cloud_tenants.find_by(:ems_ref => root_tenant_id),
-          :type          => "ManageIQ::Providers::OracleCloud::NetworkManager::CloudSubnet"
-        )
-
-        expect(vm.cloud_volumes.count).to eq(2)
-        expect(vm.cloud_volumes).to include(
-          ems.cloud_volumes.find_by(:ems_ref => "ocid1.bootvolume.oc1.iad.abuwcljthizlzlqiaumvdqheg3u4nnvn2spcepfoitx65dyqqmh2mc543gpq"),
-          ems.cloud_volumes.find_by(:ems_ref => "ocid1.volume.oc1.iad.abuwcljtuksa3l3ws63kvbtjpbh4vlwude4hiaipht6raafofxo2jhi4z5zq")
-        )
-      end
-
-      def assert_specific_image
-        template = ems.miq_templates.find_by(:ems_ref => "ocid1.image.oc1.iad.aaaaaaaaqdc7jslbtue7abhwvxaq3ihvazfvihhs2rwk2mvciv36v7ux5sda")
-        expect(template).to have_attributes(
-          :vendor          => "oracle",
-          :name            => "Oracle-Linux-7.9-2021.01.12-0",
-          :location        => "unknown",
-          :uid_ems         => "ocid1.image.oc1.iad.aaaaaaaaqdc7jslbtue7abhwvxaq3ihvazfvihhs2rwk2mvciv36v7ux5sda",
-          :power_state     => "never",
-          :type            => "ManageIQ::Providers::OracleCloud::CloudManager::Template",
-          :ems_ref         => "ocid1.image.oc1.iad.aaaaaaaaqdc7jslbtue7abhwvxaq3ihvazfvihhs2rwk2mvciv36v7ux5sda",
-          :raw_power_state => "never"
-        )
-
-        expect(template.hardware).to have_attributes(
-          :guest_os            => "linux_oracle",
-          :size_on_disk        => 50_010_783_744,
-          :virtualization_type => "NATIVE",
-          :root_device_type    => "PARAVIRTUALIZED"
-        )
-        expect(template.operating_system).to have_attributes(
-          :product_name => "Oracle Linux 7.9"
-        )
-      end
-
-      def assert_specific_cloud_network
-        cloud_network = ems.cloud_networks.first
-        expect(cloud_network).to have_attributes(
-          :ems_id       => ems.network_manager.id,
-          :name         => "vcn-20210223-1239",
-          :ems_ref      => "ocid1.vcn.oc1.iad.amaaaaaaw3enqvya24pw6a2kqhuwllzk5447qch6cdemiqvxdlnahagepodq",
-          :cidr         => "10.0.0.0/16",
-          :status       => "AVAILABLE",
-          :cloud_tenant => ems.cloud_tenants.find_by(:ems_ref => root_tenant_id),
-          :type         => "ManageIQ::Providers::OracleCloud::NetworkManager::CloudNetwork"
-        )
-      end
-
-      def assert_specific_cloud_subnet
-        cloud_subnet = ems.cloud_subnets.first
-        expect(cloud_subnet).to have_attributes(
-          :ems_id        => ems.network_manager.id,
-          :name          => "subnet-20210223-1239",
-          :ems_ref       => "ocid1.subnet.oc1.iad.aaaaaaaanmzazihpr74jpktyicjibszf3dyye4tho43nxemsixabsc7ugdqq",
-          :cloud_network => ems.cloud_networks.find_by(:ems_ref => "ocid1.vcn.oc1.iad.amaaaaaaw3enqvya24pw6a2kqhuwllzk5447qch6cdemiqvxdlnahagepodq"),
-          :cidr          => "10.0.0.0/24",
-          :status        => "AVAILABLE",
-          :gateway       => "10.0.0.1",
-          :cloud_tenant  => ems.cloud_tenants.find_by(:ems_ref => root_tenant_id),
-          :type          => "ManageIQ::Providers::OracleCloud::NetworkManager::CloudSubnet"
-        )
-      end
-
-      def assert_specific_cloud_volume
-        cloud_volume = ems.cloud_volumes.first
-        expect(cloud_volume).to have_attributes(
-          :type              => "ManageIQ::Providers::OracleCloud::CloudManager::CloudVolume",
-          :ems_ref           => "ocid1.bootvolume.oc1.iad.abuwcljthizlzlqiaumvdqheg3u4nnvn2spcepfoitx65dyqqmh2mc543gpq",
-          :size              => 50_010_783_744,
-          :availability_zone => ems.availability_zones.find_by(:name => "Foha:US-ASHBURN-AD-3"),
-          :name              => "instance-20210223-1239 (Boot Volume)",
-          :status            => "AVAILABLE",
-          :cloud_tenant      => ems.cloud_tenants.find_by(:ems_ref => root_tenant_id)
-        )
-      end
     end
 
     context "targeted refresh" do
@@ -184,7 +41,7 @@ describe ManageIQ::Providers::OracleCloud::CloudManager::Refresher do
         with_vcr("vm_target") { refresh(ems_event.manager_refresh_targets) }
 
         vm.reload
-        expect(vm.raw_power_state).to eq("STOPPED")
+        assert_specific_instance(:expected_raw_power_state => "STOPPED", :expected_power_state => "off")
       end
 
       it "doesn't impact other inventory" do
@@ -212,6 +69,149 @@ describe ManageIQ::Providers::OracleCloud::CloudManager::Refresher do
       expect(ems.miq_templates.count).to eq(100)
       expect(ems.network_ports.count).to eq(1)
       expect(ems.vms.count).to eq(1)
+    end
+
+    def assert_specific_availability_zone
+      az = ems.availability_zones.find_by(:name => "Foha:US-ASHBURN-AD-3")
+      expect(az).to have_attributes(
+        :name    => "Foha:US-ASHBURN-AD-3",
+        :ems_ref => "ocid1.availabilitydomain.oc1..aaaaaaaatrwxaogr7dl4yschqtrmqrdv6uzis3mgbnomiagqrfhcb7mxsfdq",
+        :type    => "ManageIQ::Providers::OracleCloud::CloudManager::AvailabilityZone"
+      )
+    end
+
+    def assert_specific_cloud_tenant
+      cloud_tenant = ems.cloud_tenants.find_by(:ems_ref => root_tenant_id)
+      expect(cloud_tenant).to have_attributes(
+        :ems_ref     => root_tenant_id,
+        :name        => "manageiq",
+        :description => "manageiq",
+        :enabled     => true,
+        :parent      => nil
+      )
+    end
+
+    def assert_specific_flavor
+      flavor = ems.flavors.find_by(:ems_ref => "VM.Standard.E2.1.Micro")
+      expect(flavor).to have_attributes(
+        :name    => "VM.Standard.E2.1.Micro",
+        :cpus    => 1,
+        :memory  => 1.gigabyte,
+        :ems_ref => "VM.Standard.E2.1.Micro",
+        :type    => "ManageIQ::Providers::OracleCloud::CloudManager::Flavor"
+      )
+    end
+
+    def assert_specific_instance(expected_raw_power_state: "RUNNING", expected_power_state: "on")
+      vm = ems.vms.find_by(:ems_ref => "ocid1.instance.oc1.iad.anuwcljtw3enqvycv47dx6ewcsmpjqzazpqxblsikzzkiw7ubhhgopqf3i3q")
+      expect(vm).to have_attributes(
+        :vendor            => "oracle",
+        :name              => "instance-20210223-1239",
+        :location          => root_tenant_id,
+        :uid_ems           => "ocid1.instance.oc1.iad.anuwcljtw3enqvycv47dx6ewcsmpjqzazpqxblsikzzkiw7ubhhgopqf3i3q",
+        :power_state       => expected_power_state,
+        :type              => "ManageIQ::Providers::OracleCloud::CloudManager::Vm",
+        :ems_ref           => "ocid1.instance.oc1.iad.anuwcljtw3enqvycv47dx6ewcsmpjqzazpqxblsikzzkiw7ubhhgopqf3i3q",
+        :flavor            => ems.flavors.find_by(:ems_ref => "VM.Standard.E2.1.Micro"),
+        :raw_power_state   => expected_raw_power_state,
+        :genealogy_parent  => ems.miq_templates.find_by(:ems_ref => "ocid1.image.oc1.iad.aaaaaaaaqdc7jslbtue7abhwvxaq3ihvazfvihhs2rwk2mvciv36v7ux5sda"),
+        :cloud_tenant      => ems.cloud_tenants.find_by(:ems_ref => root_tenant_id),
+        :availability_zone => ems.availability_zones.find_by(:name => "Foha:US-ASHBURN-AD-3")
+      )
+
+      expect(vm.network_ports.count).to eq(1)
+      expect(vm.network_ports.first).to have_attributes(
+        :ems_ref      => "ocid1.vnic.oc1.iad.abuwcljt5ddcgxptz6arjcdfpje74zydmpfrpqeg2kjkbwiax26rwo36nzfa",
+        :name         => "instance-20210223-1239",
+        :type         => "ManageIQ::Providers::OracleCloud::NetworkManager::NetworkPort",
+        :mac_address  => "02:00:17:09:70:43",
+        :status       => "AVAILABLE",
+        :device       => vm,
+        :cloud_tenant => ems.cloud_tenants.find_by(:ems_ref => root_tenant_id)
+      )
+
+      expect(vm.cloud_subnets.count).to eq(1)
+      expect(vm.cloud_subnets.first).to have_attributes(
+        :ems_ref       => "ocid1.subnet.oc1.iad.aaaaaaaanmzazihpr74jpktyicjibszf3dyye4tho43nxemsixabsc7ugdqq",
+        :name          => "subnet-20210223-1239",
+        :cloud_network => ems.cloud_networks.find_by(:ems_ref => "ocid1.vcn.oc1.iad.amaaaaaaw3enqvya24pw6a2kqhuwllzk5447qch6cdemiqvxdlnahagepodq"),
+        :cidr          => "10.0.0.0/24",
+        :status        => "AVAILABLE",
+        :gateway       => "10.0.0.1",
+        :cloud_tenant  => ems.cloud_tenants.find_by(:ems_ref => root_tenant_id),
+        :type          => "ManageIQ::Providers::OracleCloud::NetworkManager::CloudSubnet"
+      )
+
+      expect(vm.cloud_volumes.count).to eq(2)
+      expect(vm.cloud_volumes).to include(
+        ems.cloud_volumes.find_by(:ems_ref => "ocid1.bootvolume.oc1.iad.abuwcljthizlzlqiaumvdqheg3u4nnvn2spcepfoitx65dyqqmh2mc543gpq"),
+        ems.cloud_volumes.find_by(:ems_ref => "ocid1.volume.oc1.iad.abuwcljtuksa3l3ws63kvbtjpbh4vlwude4hiaipht6raafofxo2jhi4z5zq")
+      )
+    end
+
+    def assert_specific_image
+      template = ems.miq_templates.find_by(:ems_ref => "ocid1.image.oc1.iad.aaaaaaaaqdc7jslbtue7abhwvxaq3ihvazfvihhs2rwk2mvciv36v7ux5sda")
+      expect(template).to have_attributes(
+        :vendor          => "oracle",
+        :name            => "Oracle-Linux-7.9-2021.01.12-0",
+        :location        => "unknown",
+        :uid_ems         => "ocid1.image.oc1.iad.aaaaaaaaqdc7jslbtue7abhwvxaq3ihvazfvihhs2rwk2mvciv36v7ux5sda",
+        :power_state     => "never",
+        :type            => "ManageIQ::Providers::OracleCloud::CloudManager::Template",
+        :ems_ref         => "ocid1.image.oc1.iad.aaaaaaaaqdc7jslbtue7abhwvxaq3ihvazfvihhs2rwk2mvciv36v7ux5sda",
+        :raw_power_state => "never"
+      )
+
+      expect(template.hardware).to have_attributes(
+        :guest_os            => "linux_oracle",
+        :size_on_disk        => 50_010_783_744,
+        :virtualization_type => "NATIVE",
+        :root_device_type    => "PARAVIRTUALIZED"
+      )
+      expect(template.operating_system).to have_attributes(
+        :product_name => "Oracle Linux 7.9"
+      )
+    end
+
+    def assert_specific_cloud_network
+      cloud_network = ems.cloud_networks.first
+      expect(cloud_network).to have_attributes(
+        :ems_id       => ems.network_manager.id,
+        :name         => "vcn-20210223-1239",
+        :ems_ref      => "ocid1.vcn.oc1.iad.amaaaaaaw3enqvya24pw6a2kqhuwllzk5447qch6cdemiqvxdlnahagepodq",
+        :cidr         => "10.0.0.0/16",
+        :status       => "AVAILABLE",
+        :cloud_tenant => ems.cloud_tenants.find_by(:ems_ref => root_tenant_id),
+        :type         => "ManageIQ::Providers::OracleCloud::NetworkManager::CloudNetwork"
+      )
+    end
+
+    def assert_specific_cloud_subnet
+      cloud_subnet = ems.cloud_subnets.first
+      expect(cloud_subnet).to have_attributes(
+        :ems_id        => ems.network_manager.id,
+        :name          => "subnet-20210223-1239",
+        :ems_ref       => "ocid1.subnet.oc1.iad.aaaaaaaanmzazihpr74jpktyicjibszf3dyye4tho43nxemsixabsc7ugdqq",
+        :cloud_network => ems.cloud_networks.find_by(:ems_ref => "ocid1.vcn.oc1.iad.amaaaaaaw3enqvya24pw6a2kqhuwllzk5447qch6cdemiqvxdlnahagepodq"),
+        :cidr          => "10.0.0.0/24",
+        :status        => "AVAILABLE",
+        :gateway       => "10.0.0.1",
+        :cloud_tenant  => ems.cloud_tenants.find_by(:ems_ref => root_tenant_id),
+        :type          => "ManageIQ::Providers::OracleCloud::NetworkManager::CloudSubnet"
+      )
+    end
+
+    def assert_specific_cloud_volume
+      cloud_volume = ems.cloud_volumes.first
+      expect(cloud_volume).to have_attributes(
+        :type              => "ManageIQ::Providers::OracleCloud::CloudManager::CloudVolume",
+        :ems_ref           => "ocid1.bootvolume.oc1.iad.abuwcljthizlzlqiaumvdqheg3u4nnvn2spcepfoitx65dyqqmh2mc543gpq",
+        :size              => 50_010_783_744,
+        :availability_zone => ems.availability_zones.find_by(:name => "Foha:US-ASHBURN-AD-3"),
+        :name              => "instance-20210223-1239 (Boot Volume)",
+        :status            => "AVAILABLE",
+        :cloud_tenant      => ems.cloud_tenants.find_by(:ems_ref => root_tenant_id)
+      )
     end
 
     def with_vcr(suffix = nil, &block)


### PR DESCRIPTION
Reduce the number of methods that providers have to override from core inventory classes

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/21225