### PR TITLE
The identity service's URL has changed in the latest gem version

### DIFF
--- a/manageiq-providers-oracle_cloud.gemspec
+++ b/manageiq-providers-oracle_cloud.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "oci"
+  spec.add_dependency "oci", "~> 2.16"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov"

--- a/spec/vcr_cassettes/manageiq/providers/oracle_cloud/cloud_manager.yml
+++ b/spec/vcr_cassettes/manageiq/providers/oracle_cloud/cloud_manager.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://identity.us-ashburn-1.oraclecloud.com/20160918/users/ocid1.user.oc1..aaaaaaaa
+    uri: https://identity.us-ashburn-1.oci.oraclecloud.com/20160918/users/ocid1.user.oc1..aaaaaaaa
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/manageiq/providers/oracle_cloud/cloud_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/oracle_cloud/cloud_manager/refresher.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://identity.us-ashburn-1.oraclecloud.com/20160918/compartments/ocid1.tenancy.oc1..aaaaaaaa
+    uri: https://identity.us-ashburn-1.oci.oraclecloud.com/20160918/compartments/ocid1.tenancy.oc1..aaaaaaaa
     body:
       encoding: US-ASCII
       string: ''
@@ -51,7 +51,7 @@ http_interactions:
   recorded_at: Fri, 13 Aug 2021 19:23:00 GMT
 - request:
     method: get
-    uri: https://identity.us-ashburn-1.oraclecloud.com/20160918/compartments/?accessLevel=ANY&compartmentId=ocid1.tenancy.oc1..aaaaaaaa&compartmentIdInSubtree=true
+    uri: https://identity.us-ashburn-1.oci.oraclecloud.com/20160918/compartments/?accessLevel=ANY&compartmentId=ocid1.tenancy.oc1..aaaaaaaa&compartmentIdInSubtree=true
     body:
       encoding: US-ASCII
       string: ''
@@ -100,7 +100,7 @@ http_interactions:
   recorded_at: Fri, 13 Aug 2021 19:23:00 GMT
 - request:
     method: get
-    uri: https://identity.us-ashburn-1.oraclecloud.com/20160918/availabilityDomains/?compartmentId=ocid1.tenancy.oc1..aaaaaaaa
+    uri: https://identity.us-ashburn-1.oci.oraclecloud.com/20160918/availabilityDomains/?compartmentId=ocid1.tenancy.oc1..aaaaaaaa
     body:
       encoding: US-ASCII
       string: ''
@@ -147,7 +147,7 @@ http_interactions:
   recorded_at: Fri, 13 Aug 2021 19:23:01 GMT
 - request:
     method: get
-    uri: https://identity.us-ashburn-1.oraclecloud.com/20160918/availabilityDomains/?compartmentId=ocid1.compartment.oc1..aaaaaaaaxjfejit7hoixj4wq3nki5p6xubbqzxugrryrt4qdyt6abx566hgq
+    uri: https://identity.us-ashburn-1.oci.oraclecloud.com/20160918/availabilityDomains/?compartmentId=ocid1.compartment.oc1..aaaaaaaaxjfejit7hoixj4wq3nki5p6xubbqzxugrryrt4qdyt6abx566hgq
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
The 2.16.0 version of the oci ruby gem uses identity.REGION.oci.oraclecloud.com for the identity service URL (https://github.com/oracle/oci-ruby-sdk/blob/master/lib/oci/identity/identity_client.rb#L87) updated by (https://github.com/oracle/oci-ruby-sdk/pull/65/files) https://github.com/oracle/oci-ruby-sdk/blame/6655d215f5ccdfd3363ee35b8b150a36ed2f7fbf/lib/oci/identity/identity_client.rb#L87

Marking morphy/yes? as this is failing on master (https://app.travis-ci.com/github/ManageIQ/manageiq-providers-oracle_cloud/builds/245376636) and morphy (https://app.travis-ci.com/github/ManageIQ/manageiq-providers-oracle_cloud/builds/245376633)