### PR TITLE
Only require the parts of OCI that we need

### DIFF
--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/stream.rb
@@ -13,6 +13,8 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Stream
   end
 
   def poll
+    require "oci/streaming/streaming"
+
     # First create the target kafka topic that we will subscribe to
     stream = find_or_create_stream!
 
@@ -63,6 +65,8 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Stream
     all_rules = events_client.list_rules(compartment_id).data
     manageiq_events_rule = all_rules.select { |rule| rule.lifecycle_state == "ACTIVE" }.detect { |rule| rule.display_name == "manageiq-events" }
     return manageiq_events_rule if manageiq_events_rule.present?
+
+    require "oci/events/events"
 
     result = events_client.create_rule(
       OCI::Events::Models::CreateRuleDetails.new(

--- a/app/models/manageiq/providers/oracle_cloud/container_manager.rb
+++ b/app/models/manageiq/providers/oracle_cloud/container_manager.rb
@@ -216,6 +216,7 @@ class ManageIQ::Providers::OracleCloud::ContainerManager < ManageIQ::Providers::
     end
 
     def bearer_token(tenant, user, private_key, public_key, region, cluster_id)
+      require "oci/container_engine/container_engine"
       config                  = oci_config(tenant, user, private_key, public_key, region)
       container_engine_client = OCI::ContainerEngine::ContainerEngineClient.new(:config => config)
 

--- a/app/models/manageiq/providers/oracle_cloud/oci_connect_mixin.rb
+++ b/app/models/manageiq/providers/oracle_cloud/oci_connect_mixin.rb
@@ -3,7 +3,9 @@ module ManageIQ::Providers::OracleCloud::OciConnectMixin
 
   module ClassMethods
     def oci_config(tenant, user, private_key, public_key, region)
-      require "oci"
+      require "oci/common"
+      require "oci/auth/auth"
+      require "oci/object_storage/object_storage" # The core OCI::Response checks for OCI::ObjectStorage::ListObjects
 
       # Strip out any "----- BEGIN/END PUBLIC KEY -----" lines
       public_key.gsub!(/-----(BEGIN|END) PUBLIC KEY-----/, "")


### PR DESCRIPTION
Requires:

- [x] https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/52

Ensure the correct OCI packages are included. This is needed because we are no longer including all of the oci gem.