### PR TITLE
Remove old style gettext initializer and the empty pot file

### DIFF
--- a/config/initializers/gettext.rb
+++ b/config/initializers/gettext.rb
@@ -1,5 +1,0 @@
-Vmdb::Gettext::Domains.add_domain(
-  'ManageIQ_Providers_OracleCloud',
-  ManageIQ::Providers::OracleCloud::Engine.root.join('locale').to_s,
-  :po
-)


### PR DESCRIPTION
As of this pull request: https://github.com/ManageIQ/manageiq/pull/20490
The plugin generator no longer generates a config/initializer for populating the
gettext domain.  Instead, we pull all of the messages from the plugins into the
core manageiq.pot/po.

This commit removes this initializer and the empty .pot file.

Note, the locale/.keep is still in the plugin generator so we can clean this up
when we no longer generate plugins with it:
https://github.com/ManageIQ/manageiq/blob/7a173240b0c4fe707e6943495de27bb3589e9bcc/lib/generators/manageiq/plugin/plugin_generator.rb#L53