### PR TITLE
Fix provider_region DDF options after refactoring

### DIFF
--- a/app/models/manageiq/providers/oracle_cloud/regions.rb
+++ b/app/models/manageiq/providers/oracle_cloud/regions.rb
@@ -1,6 +1,10 @@
 module ManageIQ
   module Providers::OracleCloud
     class Regions < ManageIQ::Providers::Regions
+      def self.regions_for_options
+        all.sort_by { |r| r[:name].downcase }.map { |r| {:label => r[:name], :value => r[:name]} }
+      end
+
       private_class_method def self.from_source
         require "oci/regions_definitions"
         OCI::Regions::REGION_ENUM


### PR DESCRIPTION
Fix the provider_regions dropdown when creating an oracle cloud/container manager after this refactoring https://github.com/ManageIQ/manageiq-providers-oracle_cloud/pull/35/files#diff-f71f2c025ea05f451731f777e141c0fef5d69d6cc71d88c98867b86c0bcb9533L43-L45