### PR TITLE
Delete cloud database support

### DIFF
--- a/spec/models/manageiq/providers/oracle_cloud/cloud_manager/cloud_database_spec.rb
+++ b/spec/models/manageiq/providers/oracle_cloud/cloud_manager/cloud_database_spec.rb
@@ -7,20 +7,20 @@ describe ManageIQ::Providers::OracleCloud::CloudManager::CloudDatabase do
     FactoryBot.create(:cloud_database_oracle, :ext_management_system => ems, :name => "test-db")
   end
 
-  describe 'cloud database actions' do
+  describe 'oracle cloud database actions' do
+    let(:connection) do
+      double("OCI::Database::DatabaseClient")
+    end
+
+    before do
+      allow(ems).to receive(:with_provider_connection).and_yield(connection)
+    end
+
     context '#create_oracle_database' do
       require 'oci/database/database'
 
-      let(:connection) do
-        double("OCI::Database::DatabaseClient")
-      end
-
       let(:db_info) do
         double("OCI::Database::Models::CreateAutonomousDatabaseDetails")
-      end
-
-      before do
-        allow(ems).to receive(:with_provider_connection).and_yield(connection)
       end
 
       it 'creates an Oracle database' do
@@ -40,46 +40,64 @@ describe ManageIQ::Providers::OracleCloud::CloudManager::CloudDatabase do
                                                              :cpu_cores      => 1,
                                                              :storage        => 1})
       end
+    end
 
-      context '#create_mysql_database' do
-        require 'oci/mysql/mysql'
+    context '#delete_oracle_database' do
+      it 'deletes the Oracle database' do
+        expect(connection).to receive(:delete_autonomous_database).with(cloud_database.ems_ref)
+        cloud_database.db_engine = "Oracle Database"
+        cloud_database.delete_cloud_database
+      end
+    end
+  end
 
-        let(:connection) do
-          double("OCI::Mysql::DbSystemClient")
-        end
+  describe 'mysql cloud database actions' do
+    let(:connection) do
+      double("OCI::Mysql::DbSystemClient")
+    end
 
-        let(:db_info) do
-          double("OCI::Mysql::Models::CreateDbSystemDetails")
-        end
+    before do
+      allow(ems).to receive(:with_provider_connection).and_yield(connection)
+    end
 
-        let(:cloud_subnet) do
-          FactoryBot.create(:cloud_subnet_oracle)
-        end
+    context '#create_mysql_database' do
+      require 'oci/mysql/mysql'
 
-        before do
-          allow(ems).to receive(:with_provider_connection).and_yield(connection)
-        end
+      let(:db_info) do
+        double("OCI::Mysql::Models::CreateDbSystemDetails")
+      end
 
-        it 'creates a MySQL database' do
-          expect(OCI::Mysql::Models::CreateDbSystemDetails)
-            .to receive(:new).with(:display_name        => cloud_database.name,
-                                   :admin_username      => "user123",
-                                   :admin_password      => "test123",
-                                   :shape_name          => "MySQL.VM.Standard.E3.1.8GB",
-                                   :subnet_id           => cloud_subnet.ems_ref,
-                                   :availability_domain => "Foha:US-ASHBURN-AD-1",
-                                   :compartment_id      => "ocid1.tenancy.oc1..aaaaaaaag6mtonzmundadix23pw4ygwkha3bu3yenzryclsvblo5tg2qadrq").and_return(db_info)
-          expect(connection).to receive(:create_db_system).and_return(db_info)
+      let(:cloud_subnet) do
+        FactoryBot.create(:cloud_subnet_oracle)
+      end
 
-          cloud_database.class.raw_create_cloud_database(ems, {:name                => cloud_database.name,
-                                                               :compartment_id      => "ocid1.tenancy.oc1..aaaaaaaag6mtonzmundadix23pw4ygwkha3bu3yenzryclsvblo5tg2qadrq",
-                                                               :database            => "mysql",
-                                                               :username            => "user123",
-                                                               :password            => "test123",
-                                                               :shape_name          => "MySQL.VM.Standard.E3.1.8GB",
-                                                               :subnet              => cloud_subnet.id.to_s,
-                                                               :availability_domain => "Foha:US-ASHBURN-AD-1"})
-        end
+      it 'creates a MySQL database' do
+        expect(OCI::Mysql::Models::CreateDbSystemDetails)
+          .to receive(:new).with(:display_name        => cloud_database.name,
+                                 :admin_username      => "user123",
+                                 :admin_password      => "test123",
+                                 :shape_name          => "MySQL.VM.Standard.E3.1.8GB",
+                                 :subnet_id           => cloud_subnet.ems_ref,
+                                 :availability_domain => "Foha:US-ASHBURN-AD-1",
+                                 :compartment_id      => "ocid1.tenancy.oc1..aaaaaaaag6mtonzmundadix23pw4ygwkha3bu3yenzryclsvblo5tg2qadrq").and_return(db_info)
+        expect(connection).to receive(:create_db_system).and_return(db_info)
+
+        cloud_database.class.raw_create_cloud_database(ems, {:name                => cloud_database.name,
+                                                             :compartment_id      => "ocid1.tenancy.oc1..aaaaaaaag6mtonzmundadix23pw4ygwkha3bu3yenzryclsvblo5tg2qadrq",
+                                                             :database            => "mysql",
+                                                             :username            => "user123",
+                                                             :password            => "test123",
+                                                             :shape_name          => "MySQL.VM.Standard.E3.1.8GB",
+                                                             :subnet              => cloud_subnet.id.to_s,
+                                                             :availability_domain => "Foha:US-ASHBURN-AD-1"})
+      end
+    end
+
+    context '#delete_mysql_database' do
+      it 'deletes the MySQL database' do
+        expect(connection).to receive(:delete_db_system).with(cloud_database.ems_ref)
+        cloud_database.db_engine = "MySQL"
+        cloud_database.delete_cloud_database
       end
     end
   end


### PR DESCRIPTION
- added support to delete databases on oracle cloud
- refactored spec tests to better differentiate oracle and mysql database actions

@miq-bot assign @agrare 
@miq-bot add_label enhancement