### PR TITLE
Add proxy support for oracle cloud

### DIFF
--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager.rb
@@ -45,7 +45,7 @@ class ManageIQ::Providers::OracleCloud::CloudManager < ManageIQ::Providers::Clou
       api_client_klass = "OCI::#{service}".safe_constantize
       raise ArgumentError, _("Invalid service") if api_client_klass.nil?
 
-      api_client_klass.new(options.reverse_merge(:config => config))
+      api_client_klass.new(options.reverse_merge(:config => config, :proxy_settings => self.class.oci_proxy_settings))
     else
       config
     end
@@ -154,7 +154,7 @@ class ManageIQ::Providers::OracleCloud::CloudManager < ManageIQ::Providers::Clou
     private_key ||= find(args["id"]).authentication_token("default")
 
     config = raw_connect(tenant, user, private_key, public_key, region)
-    identity_api = OCI::Identity::IdentityClient.new(:config => config)
+    identity_api = OCI::Identity::IdentityClient.new(:config => config, :proxy_settings => oci_proxy_settings)
     !!identity_api.get_user(user)
   end
 

--- a/app/models/manageiq/providers/oracle_cloud/oci_connect_mixin.rb
+++ b/app/models/manageiq/providers/oracle_cloud/oci_connect_mixin.rb
@@ -21,5 +21,11 @@ module ManageIQ::Providers::OracleCloud::OciConnectMixin
 
       config
     end
+
+    def oci_proxy_settings
+      return if http_proxy.nil?
+
+      OCI::ApiClientProxySettings.new(http_proxy[:host], http_proxy[:port], http_proxy[:user], http_proxy[:password])
+    end
   end
 end


### PR DESCRIPTION
We were not setting the OCI proxy_settings so a proxy in settings was not being honored

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/21895