### PR TITLE
Fix private method event_stream called error

### DIFF
--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/runner.rb
@@ -28,8 +28,7 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner < Man
 
   private
 
-  attr_reader   :ems
-  attr_accessor :event_stream
+  attr_reader :ems, :event_stream
 
   def parse_event(event)
     ManageIQ::Providers::OracleCloud::CloudManager::EventParser.event_to_hash(event, ems_id)
@@ -40,11 +39,11 @@ class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner < Man
   end
 
   def ensure_event_stream
-    self.event_stream ||= ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Stream.new(ems)
+    @event_stream ||= ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Stream.new(ems)
   end
 
   def reset_event_stream
-    self.event_stream = nil
+    @event_stream = nil
   end
 
   def ems_id


### PR DESCRIPTION
Using the accessor method was causing a private method call exception

```
MIQ(ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner#start_event_monitor) EMS [] as [] Starting Event Monitor Thread
MIQ(ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner#start_event_monitor) EMS [] as [] Started Event Monitor Thread
MIQ(ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner#start_event_monitor) EMS [] as [] Event Monitor Thread aborted because [private method `event_stream' called for #<ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner:0x000055e7918ea1b0>]
[NoMethodError]: private method `event_stream' called for #<ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher::Runner:0x000055e7918ea1b0>  Method:[block (2 levels) in <class:LogProxy>]
  manageiq-providers-oracle_cloud-c988b7356399/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher/runner.rb:43:in `ensure_event_stream'
```

Fixes https://github.com/ManageIQ/manageiq-providers-oracle_cloud/issues/66