### PR TITLE
Use more performant client version by default

### DIFF
--- a/manageiq-providers-oracle_cloud.gemspec
+++ b/manageiq-providers-oracle_cloud.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "oci", "~> 2.16"
+  spec.add_dependency "oci", "~> 2.18"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
oci 2.17.0:
Memory before `require 'oci'`: 84704
Memory after `require 'oci': 368088

oci 2.18.0:
Memory before `require 'oci'`: 84808
Memory after `require 'oci': 97372

See: https://github.com/oracle/oci-ruby-sdk/issues/63