### PR TITLE
Drop lib/gem-name.rb in favor of lib/gem/name.rb

### DIFF
--- a/lib/manageiq-providers-oracle_cloud.rb
+++ b/lib/manageiq-providers-oracle_cloud.rb
@@ -1,2 +1,0 @@
-require "manageiq/providers/oracle_cloud/engine"
-require "manageiq/providers/oracle_cloud/version"

--- a/lib/manageiq/providers/oracle_cloud.rb
+++ b/lib/manageiq/providers/oracle_cloud.rb
@@ -1,1 +1,2 @@
 require "manageiq/providers/oracle_cloud/engine"
+require "manageiq/providers/oracle_cloud/version"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ end
 Dir[Rails.root.join("spec/shared/**/*.rb")].sort.each { |f| require f }
 Dir[File.join(__dir__, "support/**/*.rb")].sort.each { |f| require f }
 
-require "manageiq-providers-oracle_cloud"
+require "manageiq/providers/oracle_cloud"
 
 VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']


### PR DESCRIPTION
Adopt convention already supported by bundler and required by zeitwerk so we don't need to tell zeitwerk to ignore this lib/gem-name.rb file