### PR TITLE
Fix for blockstorage_client changed API

### DIFF
--- a/app/models/manageiq/providers/oracle_cloud/inventory/collector.rb
+++ b/app/models/manageiq/providers/oracle_cloud/inventory/collector.rb
@@ -12,7 +12,7 @@ class ManageIQ::Providers::OracleCloud::Inventory::Collector < ManageIQ::Provide
 
   def boot_volumes
     @boot_volumes ||= availability_domains.flat_map do |availability_domain|
-      blockstorage_client.list_boot_volumes(availability_domain.name, availability_domain.compartment_id).data
+      blockstorage_client.list_boot_volumes(:availability_domain => availability_domain.name, :compartment_id => availability_domain.compartment_id).data
     end
   end
 
@@ -105,7 +105,7 @@ class ManageIQ::Providers::OracleCloud::Inventory::Collector < ManageIQ::Provide
 
   def volumes
     @volumes ||= compartments.flat_map do |compartment|
-      blockstorage_client.list_volumes(compartment.id).data
+      blockstorage_client.list_volumes(:compartment_id => compartment.id).data
     end
   end
 

--- a/manageiq-providers-oracle_cloud.gemspec
+++ b/manageiq-providers-oracle_cloud.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "oci", "~> 2.18"
+  spec.add_dependency "oci", "~> 2.19"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"

--- a/manageiq-providers-oracle_cloud.gemspec
+++ b/manageiq-providers-oracle_cloud.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "oci", "~> 2.19"
+  spec.add_dependency "oci", "~> 2.19.0"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
The blockstorage_client API changed from positional arguments to a single hash argument.

Ref: https://github.com/oracle/oci-ruby-sdk/pull/72/files#r1353047628