### PR TITLE
Drop require_nested

### DIFF
--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager.rb
@@ -1,20 +1,4 @@
 class ManageIQ::Providers::OracleCloud::CloudManager < ManageIQ::Providers::CloudManager
-  require_nested :AvailabilityZone
-  require_nested :CloudDatabase
-  require_nested :CloudTenant
-  require_nested :CloudVolume
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :Flavor
-  require_nested :MetricsCapture
-  require_nested :MetricsCollectorWorker
-  require_nested :ProvisionWorkflow
-  require_nested :Provision
-  require_nested :Refresher
-  require_nested :RefreshWorker
-  require_nested :Template
-  require_nested :Vm
-
   include ManageIQ::Providers::OracleCloud::OciConnectMixin
 
   supports :create

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/event_catcher.rb
@@ -1,4 +1,2 @@
 class ManageIQ::Providers::OracleCloud::CloudManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
-  require_nested :Stream
 end

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/metrics_collector_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::OracleCloud::CloudManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
-  require_nested :Runner
-
   self.default_queue_name = "oracle"
 
   def friendly_name

--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/refresh_worker.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::OracleCloud::CloudManager::RefreshWorker < MiqEmsRefreshWorker
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/oracle_cloud/container_manager.rb
+++ b/app/models/manageiq/providers/oracle_cloud/container_manager.rb
@@ -1,18 +1,6 @@
 ManageIQ::Providers::Kubernetes::ContainerManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::OracleCloud::ContainerManager < ManageIQ::Providers::Kubernetes::ContainerManager
-  require_nested :Container
-  require_nested :ContainerGroup
-  require_nested :ContainerNode
-  require_nested :ContainerTemplate
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :Refresher
-  require_nested :RefreshWorker
-  require_nested :ServiceInstance
-  require_nested :ServiceOffering
-  require_nested :ServiceParametersSet
-
   include ManageIQ::Providers::OracleCloud::OciConnectMixin
 
   validates_inclusion_of :provider_region, :in => ->(_) { ManageIQ::Providers::OracleCloud::Regions.names }

--- a/app/models/manageiq/providers/oracle_cloud/container_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/oracle_cloud/container_manager/event_catcher.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::OracleCloud::ContainerManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
-
   def self.settings_name
     :event_catcher_oracle_oke
   end

--- a/app/models/manageiq/providers/oracle_cloud/container_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/oracle_cloud/container_manager/refresh_worker.rb
@@ -1,7 +1,4 @@
 class ManageIQ::Providers::OracleCloud::ContainerManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
-  require_nested :WatchThread
-
   def self.settings_name
     :ems_refresh_worker_oracle_oke
   end

--- a/app/models/manageiq/providers/oracle_cloud/inventory.rb
+++ b/app/models/manageiq/providers/oracle_cloud/inventory.rb
@@ -1,5 +1,2 @@
 class ManageIQ::Providers::OracleCloud::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
 end

--- a/app/models/manageiq/providers/oracle_cloud/inventory/collector.rb
+++ b/app/models/manageiq/providers/oracle_cloud/inventory/collector.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::OracleCloud::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :ContainerManager
-  require_nested :CloudManager
-  require_nested :NetworkManager
-  require_nested :TargetCollection
-
   def availability_domains
     @availability_domains ||= compartments.flat_map do |compartment|
       identity_client.list_availability_domains(compartment.id).data

--- a/app/models/manageiq/providers/oracle_cloud/inventory/collector/container_manager.rb
+++ b/app/models/manageiq/providers/oracle_cloud/inventory/collector/container_manager.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::OracleCloud::Inventory::Collector::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager
-  require_nested :WatchNotice
-
   private
 
   def kubernetes_connection

--- a/app/models/manageiq/providers/oracle_cloud/inventory/parser.rb
+++ b/app/models/manageiq/providers/oracle_cloud/inventory/parser.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::OracleCloud::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :ContainerManager
-  require_nested :CloudManager
-  require_nested :NetworkManager
-  require_nested :TargetCollection
-
   def parse
     availability_domains
     boot_volumes

--- a/app/models/manageiq/providers/oracle_cloud/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/oracle_cloud/inventory/parser/container_manager.rb
@@ -1,5 +1,3 @@
 class ManageIQ::Providers::OracleCloud::Inventory::Parser::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager
-  require_nested :WatchNotice
-
   include ParserMixin
 end

--- a/app/models/manageiq/providers/oracle_cloud/inventory/persister.rb
+++ b/app/models/manageiq/providers/oracle_cloud/inventory/persister.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::OracleCloud::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :ContainerManager
-  require_nested :CloudManager
-  require_nested :NetworkManager
-  require_nested :TargetCollection
-
   def initialize_inventory_collections
     add_cloud_collection(:availability_zones, :secondary_refs => {:by_name => %i(name)})
     add_cloud_collection(:cloud_tenants)

--- a/app/models/manageiq/providers/oracle_cloud/inventory/persister/container_manager.rb
+++ b/app/models/manageiq/providers/oracle_cloud/inventory/persister/container_manager.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::OracleCloud::Inventory::Persister::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager
-  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/oracle_cloud/network_manager.rb
+++ b/app/models/manageiq/providers/oracle_cloud/network_manager.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::OracleCloud::NetworkManager < ManageIQ::Providers::NetworkManager
-  require_nested :CloudNetwork
-  require_nested :LoadBalancer
-  require_nested :NetworkPort
-  require_nested :Refresher
-
   # Auth and endpoints delegations, editing of this type of manager must be disabled
   delegate :authentication_check,
            :authentication_status,


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854