### PR TITLE
drop use of unsupported_reason_add

### DIFF
--- a/app/models/manageiq/providers/oracle_cloud/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/oracle_cloud/cloud_manager/vm.rb
@@ -1,12 +1,13 @@
 class ManageIQ::Providers::OracleCloud::CloudManager::Vm < ManageIQ::Providers::CloudManager::Vm
   supports :capture
   supports_not :suspend
-  supports :terminate do
-    unsupported_reason_add(:terminate, unsupported_reason(:control)) unless supports?(:control)
-  end
+  supports(:terminate) { unsupported_reason(:control) }
   supports :reboot_guest do
-    unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports?(:control)
-    unsupported_reason_add(:reboot_guest, _("The VM is not powered on")) unless current_state == "on"
+    if current_state == "on"
+      _("The VM is not powered on")
+    else
+      unsupported_reason(:control)
+    end
   end
 
   def provider_object(connection = nil)


### PR DESCRIPTION
part of:
- https://github.com/ManageIQ/manageiq/pull/22898
 
Deprecating `unsupported_reason_add`. Returning the string instead

Note, these are all the same:

```ruby
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports_feature2?
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports?(:feature2)
unsupported_reason(:feature2) unless supports?(:feature2)
unsupported_reason(:feature2)
```
