### PR TITLE
Delegate refresh_ems class method to parent cloud manager

### DIFF
--- a/app/models/manageiq/providers/oracle_cloud/network_manager.rb
+++ b/app/models/manageiq/providers/oracle_cloud/network_manager.rb
@@ -17,6 +17,10 @@ class ManageIQ::Providers::OracleCloud::NetworkManager < ManageIQ::Providers::Ne
            :to        => :parent_manager,
            :allow_nil => true
 
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::OracleCloud::CloudManager
+  end
+
   def self.ems_type
     @ems_type ||= "oracle_cloud_network".freeze
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,8 @@
 :ems_refresh:
   :oracle_cloud:
     :refresh_interval: 15.minutes
+  :oracle_cloud_network:
+    :refresh_interval: 0
   :oke:
     :streaming_refresh: true
     :chunk_size: 1_000


### PR DESCRIPTION
Reasoning here: https://github.com/ManageIQ/manageiq-providers-azure/pull/564#issuecomment-2445034651

@miq-bot assign @agrare
@miq-bot add_label bug, radjabov/yes?
@miq-bot add_reviewer @agrare