### PR TITLE
Bump OCI gem version

### DIFF
--- a/manageiq-providers-oracle_cloud.gemspec
+++ b/manageiq-providers-oracle_cloud.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "oci", "~> 2.19.0"
+  spec.add_dependency "oci", "~> 2.22"
 
   spec.add_development_dependency "manageiq-style", "~> 1.5.0"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
The version we were using was from 2023
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
