### PR TITLE
Require oci gem where needed

### DIFF
--- a/app/models/manageiq/providers/oracle_cloud/inventory/collector.rb
+++ b/app/models/manageiq/providers/oracle_cloud/inventory/collector.rb
@@ -73,6 +73,8 @@ class ManageIQ::Providers::OracleCloud::Inventory::Collector < ManageIQ::Provide
   end
 
   def vnics
+    require "oci"
+
     # There doesn't appear to be a #list_vnics method so we have to get these
     # one-at-a-time.
     @vnics ||= vnic_attachments.map do |vnic_attachment|
@@ -141,6 +143,8 @@ class ManageIQ::Providers::OracleCloud::Inventory::Collector < ManageIQ::Provide
   end
 
   def retry_config
+    require "oci"
+
     @retry_config ||= OCI::Retry::RetryConfig.new(
       :base_sleep_time_millis            => options.retry_config.base_sleep_time.to_i_with_method * 1_000,
       :exponential_growth_factor         => options.retry_config.exponential_growth_factor,


### PR DESCRIPTION
Fixes uninitialized constant OCI::Retry errors depending on test order.

I believe OCI might be heavyweight so I'm currently delay loading OCI where needed.

Note, this manifested in test, but could possibly happen in code.

```
1) ManageIQ::Providers::OracleCloud::CloudManager::Refresher#refresh full refresh Performs a full refresh
     Failure/Error:
       @retry_config ||= OCI::Retry::RetryConfig.new(
         :base_sleep_time_millis            => options.retry_config.base_sleep_time.to_i_with_method * 1_000,
         :exponential_growth_factor         => options.retry_config.exponential_growth_factor,
         :max_attempts                      => options.retry_config.max_attempts,
         :max_elapsed_time_millis           => options.retry_config.max_elapsed_time.to_i_with_method * 1_000,
         :max_sleep_between_attempts_millis => options.retry_config.max_sleep_between_attempts.to_i_with_method * 1_000,
         :should_retry_exception_proc       => OCI::Retry::Functions::ShouldRetryOnError.retry_on_network_error_throttle_and_internal_server_errors,
         :sleep_calc_millis_proc            => OCI::Retry::Functions::Sleep.exponential_backoff_with_full_jitter
       )

     NameError:
       uninitialized constant OCI::Retry
     # ./app/models/manageiq/providers/oracle_cloud/inventory/collector.rb:144:in `retry_config'
     # ./app/models/manageiq/providers/oracle_cloud/inventory/collector.rb:132:in `identity_client'
     # ./app/models/manageiq/providers/oracle_cloud/inventory/collector.rb:26:in `compartments'
     # ./app/models/manageiq/providers/oracle_cloud/inventory/collector.rb:3:in `availability_domains'
     # ./app/models/manageiq/providers/oracle_cloud/inventory/parser.rb:17:in `availability_domains'
     # ./app/models/manageiq/providers/oracle_cloud/inventory/parser.rb:3:in `parse'
     # ./spec/manageiq/app/models/manageiq/providers/inventory.rb:38:in `block in parse'
     # ./spec/manageiq/app/models/manageiq/providers/inventory.rb:35:in `each'
     # ./spec/manageiq/app/models/manageiq/providers/inventory.rb:35:in `parse'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:131:in `parse_targeted_inventory'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:97:in `block in refresh_targets_for_ems'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:96:in `refresh_targets_for_ems'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:42:in `block (2 levels) in refresh'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:42:in `block in refresh'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:32:in `each'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:32:in `refresh'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:11:in `refresh'
     # ./spec/models/manageiq/providers/oracle_cloud/cloud_manager/refresher_spec.rb:239:in `refresh'
     # ./spec/models/manageiq/providers/oracle_cloud/cloud_manager/refresher_spec.rb:9:in `block (6 levels) in <top (required)>'
     # ./spec/models/manageiq/providers/oracle_cloud/cloud_manager/refresher_spec.rb:235:in `with_vcr'
     # ./spec/models/manageiq/providers/oracle_cloud/cloud_manager/refresher_spec.rb:9:in `block (5 levels) in <top (required)>'
     # ./spec/models/manageiq/providers/oracle_cloud/cloud_manager/refresher_spec.rb:8:in `block (4 levels) in <top (required)>'

  2) ManageIQ::Providers::OracleCloud::CloudManager::Refresher#refresh targeted refresh refreshes the target
     Failure/Error:
       @retry_config ||= OCI::Retry::RetryConfig.new(
         :base_sleep_time_millis            => options.retry_config.base_sleep_time.to_i_with_method * 1_000,
         :exponential_growth_factor         => options.retry_config.exponential_growth_factor,
         :max_attempts                      => options.retry_config.max_attempts,
         :max_elapsed_time_millis           => options.retry_config.max_elapsed_time.to_i_with_method * 1_000,
         :max_sleep_between_attempts_millis => options.retry_config.max_sleep_between_attempts.to_i_with_method * 1_000,
         :should_retry_exception_proc       => OCI::Retry::Functions::ShouldRetryOnError.retry_on_network_error_throttle_and_internal_server_errors,
         :sleep_calc_millis_proc            => OCI::Retry::Functions::Sleep.exponential_backoff_with_full_jitter
       )

     NameError:
       uninitialized constant OCI::Retry
     # ./app/models/manageiq/providers/oracle_cloud/inventory/collector.rb:144:in `retry_config'
     # ./app/models/manageiq/providers/oracle_cloud/inventory/collector.rb:132:in `identity_client'
     # ./app/models/manageiq/providers/oracle_cloud/inventory/collector.rb:26:in `compartments'
     # ./app/models/manageiq/providers/oracle_cloud/inventory/collector.rb:3:in `availability_domains'
     # ./app/models/manageiq/providers/oracle_cloud/inventory/parser.rb:17:in `availability_domains'
     # ./app/models/manageiq/providers/oracle_cloud/inventory/parser.rb:3:in `parse'
     # ./spec/manageiq/app/models/manageiq/providers/inventory.rb:38:in `block in parse'
     # ./spec/manageiq/app/models/manageiq/providers/inventory.rb:35:in `each'
     # ./spec/manageiq/app/models/manageiq/providers/inventory.rb:35:in `parse'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:131:in `parse_targeted_inventory'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:97:in `block in refresh_targets_for_ems'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:96:in `refresh_targets_for_ems'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:42:in `block (2 levels) in refresh'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:42:in `block in refresh'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:32:in `each'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:32:in `refresh'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:11:in `refresh'
     # ./spec/models/manageiq/providers/oracle_cloud/cloud_manager/refresher_spec.rb:239:in `refresh'
     # ./spec/models/manageiq/providers/oracle_cloud/cloud_manager/refresher_spec.rb:36:in `block (5 levels) in <top (required)>'
     # ./spec/models/manageiq/providers/oracle_cloud/cloud_manager/refresher_spec.rb:235:in `with_vcr'
     # ./spec/models/manageiq/providers/oracle_cloud/cloud_manager/refresher_spec.rb:36:in `block (4 levels) in <top (required)>'

  3) ManageIQ::Providers::OracleCloud::CloudManager::Refresher#refresh targeted refresh doesn't impact other inventory
     Failure/Error:
       @retry_config ||= OCI::Retry::RetryConfig.new(
         :base_sleep_time_millis            => options.retry_config.base_sleep_time.to_i_with_method * 1_000,
         :exponential_growth_factor         => options.retry_config.exponential_growth_factor,
         :max_attempts                      => options.retry_config.max_attempts,
         :max_elapsed_time_millis           => options.retry_config.max_elapsed_time.to_i_with_method * 1_000,
         :max_sleep_between_attempts_millis => options.retry_config.max_sleep_between_attempts.to_i_with_method * 1_000,
         :should_retry_exception_proc       => OCI::Retry::Functions::ShouldRetryOnError.retry_on_network_error_throttle_and_internal_server_errors,
         :sleep_calc_millis_proc            => OCI::Retry::Functions::Sleep.exponential_backoff_with_full_jitter
       )

     NameError:
       uninitialized constant OCI::Retry
     # ./app/models/manageiq/providers/oracle_cloud/inventory/collector.rb:144:in `retry_config'
     # ./app/models/manageiq/providers/oracle_cloud/inventory/collector.rb:132:in `identity_client'
     # ./app/models/manageiq/providers/oracle_cloud/inventory/collector.rb:26:in `compartments'
     # ./app/models/manageiq/providers/oracle_cloud/inventory/collector.rb:3:in `availability_domains'
     # ./app/models/manageiq/providers/oracle_cloud/inventory/parser.rb:17:in `availability_domains'
     # ./app/models/manageiq/providers/oracle_cloud/inventory/parser.rb:3:in `parse'
     # ./spec/manageiq/app/models/manageiq/providers/inventory.rb:38:in `block in parse'
     # ./spec/manageiq/app/models/manageiq/providers/inventory.rb:35:in `each'
     # ./spec/manageiq/app/models/manageiq/providers/inventory.rb:35:in `parse'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:131:in `parse_targeted_inventory'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:97:in `block in refresh_targets_for_ems'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:96:in `refresh_targets_for_ems'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:42:in `block (2 levels) in refresh'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:42:in `block in refresh'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:32:in `each'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:32:in `refresh'
     # ./spec/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:11:in `refresh'
     # ./spec/models/manageiq/providers/oracle_cloud/cloud_manager/refresher_spec.rb:239:in `refresh'
     # ./spec/models/manageiq/providers/oracle_cloud/cloud_manager/refresher_spec.rb:49:in `block (5 levels) in <top (required)>'
     # ./spec/models/manageiq/providers/oracle_cloud/cloud_manager/refresher_spec.rb:235:in `with_vcr'
     # ./spec/models/manageiq/providers/oracle_cloud/cloud_manager/refresher_spec.rb:49:in `block (4 levels) in <top (required)>'
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
